### PR TITLE
Catch error when RT responds with 403

### DIFF
--- a/src/argus_ticket_rt.py
+++ b/src/argus_ticket_rt.py
@@ -18,7 +18,7 @@ from argus.incident.ticket.base import (
 LOG = logging.getLogger(__name__)
 
 
-__version__ = "1.0"
+__version__ = "1.0.1"
 __all__ = [
     "RequestTrackerPlugin",
 ]
@@ -125,7 +125,7 @@ class RequestTrackerPlugin(TicketPlugin):
             authentication_error = "Request Tracker: The authentication details are incorrect. Please check and update the setting 'TICKET_AUTHENTICATION_SECRET'."
             LOG.exception(authentication_error)
             raise TicketSettingsException(authentication_error)
-        except rt_exceptions.NotAllowedError:
+        except (rt_exceptions.NotAllowedError, rt_exceptions.UnexpectedResponseError):
             permission_error = "Request Tracker: Authenticated client does not have sufficient permissions."
             LOG.exception(permission_error)
             raise TicketCreationException(permission_error)


### PR DESCRIPTION
When settings up a Argus API user it was not authorized to access a queue, which resulted in an uncaught error.