### PR TITLE
Avoid ticket_information being changed during previous ticket creation

### DIFF
--- a/src/argus_ticket_rt.py
+++ b/src/argus_ticket_rt.py
@@ -82,7 +82,7 @@ class RequestTrackerPlugin(TicketPlugin):
                 custom_field = serialized_incident.get(field, None)
                 if custom_field:
                     custom_fields[key] = custom_field
-                else:
+                elif field != "end_time":
                     missing_fields.append(field)
 
         return custom_fields, missing_fields

--- a/src/argus_ticket_rt.py
+++ b/src/argus_ticket_rt.py
@@ -63,10 +63,12 @@ class RequestTrackerPlugin(TicketPlugin):
             serialized_incident["end_time"] = serialized_incident["end_time"][:-6]
         else:
             del serialized_incident["end_time"]
+
         incident_tags = RequestTrackerPlugin.convert_tags_to_dict(
             serialized_incident["tags"]
         )
-        custom_fields = ticket_information.get("custom_fields_set", {})
+        custom_fields = dict()
+        custom_fields.update(ticket_information.get("custom_fields_set", {}))
         custom_fields_mapping = ticket_information.get("custom_fields_mapping", {})
         missing_fields = []
 

--- a/src/argus_ticket_rt.py
+++ b/src/argus_ticket_rt.py
@@ -71,7 +71,7 @@ class RequestTrackerPlugin(TicketPlugin):
         missing_fields = []
 
         for key, field in custom_fields_mapping.items():
-            if type(field) is dict:
+            if isinstance(field, dict):
                 # Information can be found in tags
                 custom_field = incident_tags.get(field["tag"], None)
                 if custom_field:


### PR DESCRIPTION
I found a very fun bug:
If a custom field is a mapping from the field `end_time` and we first create a ticket for a closed incident and afterwards a ticket for an open incident, then it leads to that custom field being set to the `end_time` of the closed incident in the ticket for the open incident.

The reason for that is that I used `get` to get a `dict` out of the `dict` that is containing it (`custom_fields_set` out of `ticket_information`) and then later change that `dict` `custom_fields_set` in place. The side effect is that those changes get saved in `ticket_information`, so this information stays until it is replaced by the end time of another closed incident. 